### PR TITLE
Fix flaky tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,6 @@
-config_setting(
-    name = "windows",
-    constraint_values = ["@bazel_tools//platforms:windows"],
-)
+load("@//:config.bzl", "platform_config", "package_copt")
+
+platform_config()
 
 cc_library(
     name = "timer",
@@ -12,18 +11,14 @@ cc_library(
         "src/timer.cpp",
     ],
     strip_include_prefix = "include",
-    copts = select({":windows" : ["/std:c++17"],
-    "//conditions:default" : ["-std=c++17"],}),
+    copts = package_copt,
     visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "test_timer",
     srcs = ["test/test_timer.cpp"],
-    copts = select({":windows" : ["/std:c++17"],
-                    "//conditions:default" : ["-std=c++17"],
-                }
-    ),
+    copts = package_copt,
     tags = ["unit"],
     deps = [
         ":timer",

--- a/config.bzl
+++ b/config.bzl
@@ -1,0 +1,10 @@
+
+def platform_config():
+    native.config_setting(
+        name = "windows",
+        constraint_values = ["@bazel_tools//platforms:windows"],
+        visibility = ["//visibility:public"]
+    )
+
+package_copt = select({":windows" : ["/std:c++17"],
+    "//conditions:default" : ["-std=c++17"],})


### PR DESCRIPTION
1. Use a test fixture, to avoid explicit instantiation of timer object in every test
2. Fix flaky tests.
3. Move the config_setting variable to correct place, for global availability.